### PR TITLE
use setImmediate() instead of nextTick() for gc

### DIFF
--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -501,7 +501,7 @@ _.extend(Writer.prototype, {
                     self._resetBlocks();
                     if (final) {
                         self.emit('end');
-                        process.nextTick(function() {
+                        setImmediate(function() {
                             self.destroy();
                         });
                     }
@@ -511,7 +511,7 @@ _.extend(Writer.prototype, {
         } else {
         	if (final) {
         		self.emit('end');
-                process.nextTick(function() {
+                setImmediate(function() {
                     self.destroy();
                 });
         	}


### PR DESCRIPTION
As of node 0.9, setImmediate ensures that the callback will be run after any IO on the stack. I think this is the intended functionality, since one wouldn't want to GC the stream before the IO. When we turned up the data size to the point where the output was about 50kb, we started hitting this condition intermittently and we were getting this error:

```
Avro IO Error: Must provide an output object that implements the write method
```

. . . because `this.output` in IO was set to `null` as a result of `destroy()` having been called too early.
