### PR TITLE
Always write buffers to output to avoid any type coercion

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -171,7 +171,7 @@ BinaryEncoder.prototype = {
     },
 
     writeByte: function(value){
-        this._output.write(value);
+        this._output.write(new Buffer([value]));
     },
 
     writeNull : function() {


### PR DESCRIPTION
I had an issue where stream-buffers were coercing a number into a string, causing deserialization issues downstream. By writing only buffers to the output, the binary nature of avro serialization is more likely to play well with the writable output.
