### PR TITLE
Adding self-references to non-primitive types.

### DIFF
--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -235,7 +235,7 @@ _.extend(Block.prototype, {
     // Show a string representation of the Block
     toString: function() {
         return "Block: " + util.inspect(this.slice());
-    }, 
+    },
 
     inpect: function() {
         return this.toString();
@@ -251,7 +251,7 @@ function Reader(options) {
     options = options || {}
     options.objectMode = true;
     Transform.call(this, options);
-    
+
     this._fileBlock = new Block();
     this._datumBlock = new Block();
     this._inBody = false;
@@ -329,7 +329,7 @@ _.extend(Reader.prototype, {
 
             var codec = this.header.meta['avro.codec'].toString();
             this.decompressData(block.objects, codec, function(err, data) {
-                if (err) 
+                if (err)
 					self.emit('error',  err);
                 else {
 					if (data) {
@@ -364,7 +364,7 @@ _.extend(Reader.prototype, {
             var header = this._readHeader();
             if (!(header instanceof AvroErrors.BlockDelayReadError))
                 this._inBody = true;
-        } 
+        }
 
         if (this._inBody) {
             this._readBlocks(done);
@@ -501,7 +501,7 @@ _.extend(Writer.prototype, {
                     self._resetBlocks();
                     if (final) {
                         self.emit('end');
-                        process.nextTick(function() {
+                        setImmediate(function() {
                             self.destroy();
                         });
                     }
@@ -511,7 +511,7 @@ _.extend(Writer.prototype, {
         } else {
         	if (final) {
         		self.emit('end');
-                process.nextTick(function() {
+                setImmediate(function() {
                     self.destroy();
                 });
         	}
@@ -545,7 +545,7 @@ _.extend(Writer.prototype, {
     end: function(data) {
         var self = this;
         if (this._paused) {
-            process.nextTick(function() {
+            setImmediate(function() {
                 self.end(data);
             });
         } else {

--- a/lib/io.js
+++ b/lib/io.js
@@ -112,7 +112,7 @@ BinaryDecoder.prototype = {
         else {
             if (Buffer.isBuffer(bytes))
                 return bytes.toString();
-            else 
+            else
                 return String.fromCharCode(bytes);
         }
     },
@@ -180,7 +180,7 @@ BinaryEncoder.prototype = {
     },
 
     writeByte: function(value){
-        this._output.write(value);
+        this._output.write(new Buffer([value]));
     },
 
     writeNull : function() {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -233,7 +233,7 @@ function PrimitiveSchema(schema, type) {
             return;
         }
 
-        throw new AvroErrors.InvalidSchemaError('Primitive type must be one of: %s; got %s',
+        throw new AvroErrors.InvalidSchemaError('Primitive type must be one of: %s; or a previously self-referenced type. Got %s',
                                          JSON.stringify(PRIMITIVE_TYPES), type);
     }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -61,6 +61,7 @@ function Schema(schema, namespace) {
 }
 
 _.extend(Schema.prototype, {
+    schemaRecords: {},
 
     parse: function(schema, namespace) {
         var self = this;
@@ -78,10 +79,19 @@ _.extend(Schema.prototype, {
                     throw new AvroErrors.InvalidSchemaError('record must specify "name", got %s',
                                                      JSON.stringify(schema));
                 } else {
-                    return new RecordSchema(schema.name, schema.namespace,
+                    var record = new RecordSchema(schema.name, schema.namespace,
                                             _.map(schema.fields, function(field) {
                                                 return new FieldSchema(field.name, self.parse(field, namespace));
                                             }));
+                    // Store the schema records into a map of schema name to
+                    // record, so we can compare against it later if we find
+                    // something that isn't a primitive data type, but may
+                    // be a self-reference
+                    if (!this.schemaRecords[schema.name]) {
+                        this.schemaRecords[schema.name] = record;
+                    }
+
+                    return record;
                 }
             } else if (schema.type === 'enum') {
                 if (_.has(schema, 'symbols')) {
@@ -204,6 +214,10 @@ _.extend(Schema.prototype, {
         return false;
     },
 
+    getSchemaRecords: function() {
+        return this.schemaRecords;
+    },
+
     toString: function() {
         return JSON.stringify({ type: this.type });
     }
@@ -214,7 +228,15 @@ function PrimitiveSchema(type) {
     if (!_.isString(type)) {
         throw new AvroErrors.InvalidSchemaError('Primitive type name must be a string');
     }
+
     if (!_.contains(PRIMITIVE_TYPES, type)) {
+        var record = this.getSchemaRecords()[type];
+
+        if (record) {
+            this.type = record;
+            return;
+        }
+
         throw new AvroErrors.InvalidSchemaError('Primitive type must be one of: %s; got %s',
                                          JSON.stringify(PRIMITIVE_TYPES), type);
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -52,6 +52,7 @@ function makeFullyQualifiedTypeName(schema, namespace) {
 }
 
 function Schema(schema, namespace) {
+    this.schemaRecords = {};
 
     if ((this instanceof arguments.callee) === false)
         return new arguments.callee(schema, namespace);
@@ -61,7 +62,6 @@ function Schema(schema, namespace) {
 }
 
 _.extend(Schema.prototype, {
-    schemaRecords: {},
 
     parse: function(schema, namespace) {
         var self = this;
@@ -69,7 +69,7 @@ _.extend(Schema.prototype, {
             throw new AvroErrors.InvalidSchemaError('schema is null, in parentSchema: %s',
                                              JSON.stringify(parentSchema));
         } else if (_.isString(schema)) {
-            return new PrimitiveSchema(schema);
+            return new PrimitiveSchema(this, schema);
         } else if (_.isObject(schema) && !_.isArray(schema)) {
             if (schema.type === 'record') {
                 if (!_.has(schema, 'fields')) {
@@ -214,23 +214,19 @@ _.extend(Schema.prototype, {
         return false;
     },
 
-    getSchemaRecords: function() {
-        return this.schemaRecords;
-    },
-
     toString: function() {
         return JSON.stringify({ type: this.type });
     }
 });
 
-function PrimitiveSchema(type) {
+function PrimitiveSchema(schema, type) {
 
     if (!_.isString(type)) {
         throw new AvroErrors.InvalidSchemaError('Primitive type name must be a string');
     }
 
     if (!_.contains(PRIMITIVE_TYPES, type)) {
-        var record = this.getSchemaRecords()[type];
+        var record = schema.schemaRecords[type];
 
         if (record) {
             this.type = record;

--- a/test/schema.js
+++ b/test/schema.js
@@ -165,7 +165,7 @@ function PrimitiveSchema(schema, type) {
             return;
         }
 
-        throw new AvroErrors.InvalidSchemaError('Primitive type must be one of: %s; got %s',
+        throw new AvroErrors.InvalidSchemaError('Primitive type must be one of: %s; or a previously self-referenced type. Got %s',
                                          JSON.stringify(PRIMITIVE_TYPES), type);
     }
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -51,6 +51,7 @@ function makeFullyQualifiedTypeName(schema, namespace) {
 }
 
 function Schema(schema, namespace) {
+    this.schemaRecords = {};
 
     if ((this instanceof arguments.callee) === false)
         return new arguments.callee(schema, namespace);
@@ -153,7 +154,7 @@ _.extend(Schema.prototype, {
 function PrimitiveSchema(schema, type) {
 
     if (!_.isString(type)) {
-        throw new AvroErrors.InvalidSchemaError('Primitive type name must be a string');
+        throw new AvroInvalidSchemaError('Primitive type name must be a string');
     }
 
     if (!_.contains(PRIMITIVE_TYPES, type)) {

--- a/test/schema.js
+++ b/test/schema.js
@@ -60,7 +60,6 @@ function Schema(schema, namespace) {
 }
 
 _.extend(Schema.prototype, {
-    schemaRecords: {},
 
     parse: function(schema, namespace) {
         var self = this;
@@ -68,7 +67,7 @@ _.extend(Schema.prototype, {
             throw new AvroInvalidSchemaError('schema is null, in parentSchema: %s',
                                              JSON.stringify(parentSchema));
         } else if (_.isString(schema)) {
-            return new PrimitiveSchema(schema);
+            return new PrimitiveSchema(this, schema);
         } else if (_.isObject(schema) && !_.isArray(schema)) {
             if (schema.type === 'record') {
                 if (!_.has(schema, 'fields')) {
@@ -146,22 +145,19 @@ _.extend(Schema.prototype, {
         return true;
     },
 
-    getSchemaRecords: function() {
-        return this.schemaRecords;
-    },
-
     toString: function() {
         return JSON.stringify({ type: this.type });
     }
 });
 
-function PrimitiveSchema(type) {
+function PrimitiveSchema(schema, type) {
 
     if (!_.isString(type)) {
-        throw new AvroInvalidSchemaError('Primitive type name must be a string');
+        throw new AvroErrors.InvalidSchemaError('Primitive type name must be a string');
     }
+
     if (!_.contains(PRIMITIVE_TYPES, type)) {
-        var record = this.getSchemaRecords()[type];
+        var record = schema.schemaRecords[type];
 
         if (record) {
             this.type = record;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -160,5 +160,50 @@ describe('Schema()', function(){
             var selfReferenced = schema.schemas[1].fields[0].type.schemas[1].type;
             selfReferenced.should.equal(original);
         });
+        // This test is disabled due to the current inability to do a late
+        // checking. In this case we would desire the first reference to
+        // Document not initially fail. It would wait until it has reached a
+        // definition for Document or fail when it reaches the end of the schema
+        it.skip('should allow for self references that are defined later', function() {
+            var schema = Avro.Schema({
+                "name": "document",
+                "type": [
+                    {
+                        "type": "record",
+                        "name": "Fax",
+                        "fields": [
+                            {
+                              "name": "data",
+                              "type": [
+                                "null",
+                                "Document"
+                              ],
+                              "default": null
+                            }
+                        ]
+                    },
+                    {
+                        "type": "record",
+                        "name": "Document",
+                        "fields": [
+                            {
+                                "name": "test",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            });
+
+            // Ensure that the the reference to the non-primitive type 'Document'
+            // in the second element of the type array now has the value of the
+            // original 'Document'
+            var original = schema.schemas[0];
+            var selfReferenced = schema.schemas[1].fields[0].type.schemas[1].type;
+            selfReferenced.should.equal(original);
+        });
     })
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -18,16 +18,16 @@ describe('Schema()', function(){
                 var schema = Avro.Schema();
                 schema.parse();
             }).should.throwError();
-        });      
+        });
         it('should return a PrimitiveSchema if any of the primitive types are passed as schema arguments or as a type property', function(){
             var primitives = ['null', 'boolean', 'int', 'long', 'float', 'double', 'bytes', 'string'];
             _.each(primitives, function(type) {
                 var schema = Avro.Schema(type);
                 schema.should.be.an.instanceof(Avro.PrimitiveSchema);
-                schema.type.should.equal(type);  
+                schema.type.should.equal(type);
                 schema = Avro.Schema({ "type": type });
                 schema.should.be.an.instanceof(Avro.PrimitiveSchema);
-                schema.type.should.equal(type);                 
+                schema.type.should.equal(type);
             });
         });
         it('should throw an error is an unrecognized primitive type is provided', function(){
@@ -45,29 +45,29 @@ describe('Schema()', function(){
         });
         it('should throw an error if an empty array of unions is passed', function(){
             (function() {
-                var schema = Avro.Schema([]);                
+                var schema = Avro.Schema([]);
             }).should.throwError();
         })
         it('should return a RecordSchema if an object is passed with a type "record"', function(){
-            var schema = Avro.Schema({ 
-                name: "myrecord", 
-                type: "record", 
+            var schema = Avro.Schema({
+                name: "myrecord",
+                type: "record",
                 fields: [
                     {
-                        "name": "method", 
+                        "name": "method",
                         "type": "string"
-                    }, 
+                    },
                     {
-                        "name": "path", 
+                        "name": "path",
                         "type": "string"
-                    }, 
+                    },
                     {
-                        "name": "queryString", 
+                        "name": "queryString",
                         "type": [
-                            "string", 
+                            "string",
                             "null"
                         ]
-                    }, 
+                    },
                 ]
             });
             schema.should.be.an.instanceof(Avro.RecordSchema);
@@ -77,9 +77,9 @@ describe('Schema()', function(){
         });
         it('should return a MapSchema if an object is passed with a type "map"', function(){
             var schema = Avro.Schema({
-                "name": "mapSchemaTest", 
+                "name": "mapSchemaTest",
                 "type": {
-                    "type": "map", 
+                    "type": "map",
                     "values": "bytes"
                 }
             });
@@ -100,9 +100,9 @@ describe('Schema()', function(){
         });
         it('should return a FixedSchema if an object is passed with a type "fixed"', function(){
             var schema = Avro.Schema({
-                "name": "fixedSchemaTest", 
+                "name": "fixedSchemaTest",
                 "type": {
-                    "type": "fixed", 
+                    "type": "fixed",
                     "size": 50
                 }
             });
@@ -119,5 +119,46 @@ describe('Schema()', function(){
             schema.symbols.should.have.length(4);
             schema.type.should.equal("enum");
         })
+        it('should allow for self references by name for non-primitive data types', function() {
+            var schema = Avro.Schema({
+                "name": "document",
+                "type": [
+                    {
+                        "type": "record",
+                        "name": "Document",
+                        "fields": [
+                            {
+                                "name": "test",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "type": "record",
+                        "name": "Fax",
+                        "fields": [
+                            {
+                              "name": "data",
+                              "type": [
+                                "null",
+                                "Document"
+                              ],
+                              "default": null
+                            }
+                        ]
+                    }
+                ]
+            });
+
+            // Ensure that the the reference to the non-primitive type 'Document'
+            // in the second element of the type array now has the value of the
+            // original 'Document'
+            var original = schema.schemas[0];
+            var selfReferenced = schema.schemas[1].fields[0].type.schemas[1].type;
+            selfReferenced.should.equal(original);
+        });
     })
 });


### PR DESCRIPTION
I ran into an issue with the Avro schemas we use where we reference non-primitive types that have already been defined by name. I replace the non-primitive type with a copy of the original type if it's found, otherwise the non-primitive type error is thrown as usual.