### PR TITLE
use int64-native-node12 instead of int64-native for compatibility with node 0.12+

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -1,7 +1,7 @@
 var libpath = process.env['MOCHA_COV'] ? __dirname + '/../lib-cov/' : __dirname + '/';
 
 var _ = require('lodash');
-var Int64 = require("int64-native")
+var Int64 = require("int64-native-node12")
 var util = require('util');
 var Avro = require(libpath + 'schema');
 var AvroErrors = require(libpath + 'errors.js');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "^2.4.1",
     "snappy": "^2.1.1",
     "buffer-crc32": "^0.2.5",
-    "int64-native": "0.3.2"
+    "int64-native-node12": "0.4.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",


### PR DESCRIPTION
This was the only way I could get node-avro-io to install.  Not sure if you want to use it or not since I don't know if it will work with versions of node < 0.12.