### PR TITLE
Node 4.1 support

### DIFF
--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -267,7 +267,7 @@ _.extend(Reader.prototype, {
     _snappyDecompress: function(rawData, callback) {
         var compressedData = rawData.slice(0, rawData.length - 4);
         var checksum = rawData.slice(rawData.length - 4, rawData.length);
-        snappy.decompress(compressedData, snappy.parsers.raw, function(err, data) {
+        snappy.uncompress(compressedData, function(err, data) {
             if (err) return callback(err);
             var calculatedChecksum = crc32(data);
             if (calculatedChecksum.readUInt32BE(0) !== checksum.readUInt32BE(0))

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "^2.4.1",
     "snappy": "^2.1.1",
     "buffer-crc32": "^0.2.5",
-    "int64-native": "0.3.2"
+    "int64-native": "^0.4.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "lodash": "^2.4.1",
-    "snappy": "^2.1.1",
+    "snappy": "^4.0.1",
     "buffer-crc32": "^0.2.5",
     "int64-native": "^0.4.0"
   },


### PR DESCRIPTION
To get node 4.1 support, I've adopted both the new version of int64-native and snappy.

Fixes #20
Fixes #17 