### PR TITLE
Adopt snappy 5.x and update version for semvar compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v1.0.0
+
+- Adopt snappy 5.x
+- Drop support for iojs & node 0.8

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-avro-io",
   "description": "This will allow you to encode / decode avro binary format to / from json format, it supports both deflate and snappy compressions and supports node streams",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "author": {
     "name": "James Power",
     "email": "james.bruce.power@gmail.com"
@@ -16,10 +16,10 @@
     "test": "make test"
   },
   "dependencies": {
-    "lodash": "^2.4.1",
-    "snappy": "^4.0.1",
     "buffer-crc32": "^0.2.5",
-    "int64-native": "^0.4.0"
+    "int64-native": "^0.4.0",
+    "lodash": "^2.4.1",
+    "snappy": "^5.0.5"
   },
   "devDependencies": {
     "mocha": "^2.1.0",


### PR DESCRIPTION
I've done a couple of things here:

1. Updated snappy to 5.x to fix minimax security warning (and other goodness)
2. Because snappy  5.x dropped support for node < 4.x I bumped the package version to 1.x to avoid breaking < 4.x users.
3. I added a changelog because it's a good thing to do.