### PR TITLE
Update snappy to 6.1 and bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.0.0
 
 - Adopt snappy 6.x
+- Update int64-native to 0.5
 - Drop support for node 0.10 & 0.12
 
 ## v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.0.0
+
+- Adopt snappy 6.x
+- Drop support for node 0.10 & 0.12
+
 ## v1.0.0
 
 - Adopt snappy 5.x

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-avro-io",
   "description": "This will allow you to encode / decode avro binary format to / from json format, it supports both deflate and snappy compressions and supports node streams",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": {
     "name": "James Power",
     "email": "james.bruce.power@gmail.com"
@@ -28,7 +28,7 @@
     "buffer-crc32": "^0.2.5",
     "int64-native": "^0.4.0",
     "lodash": "^2.4.1",
-    "snappy": "^5.0.5"
+    "snappy": "^6.1.1"
   },
   "devDependencies": {
     "mocha": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "buffer-crc32": "^0.2.5",
-    "int64-native": "^0.4.0",
+    "int64-native": "^0.5.0",
     "lodash": "^2.4.1",
     "snappy": "^6.1.1"
   },


### PR DESCRIPTION
This PR updates snappy to 6.1 which is necessary because in v5.0, when running `npm ci`, `node-gyp rebuild` fails. The package now downloads a precompiled version of the library which should solve these problems. I've also bumped the version to 2.0.0 since snappy dropped support for node 0.10 and 0.12 in this update.